### PR TITLE
Updated all typings

### DIFF
--- a/generators/app/templates/typings.json
+++ b/generators/app/templates/typings.json
@@ -1,30 +1,30 @@
 {
   "globalDependencies": {
-    "jasmine": "github:DefinitelyTyped/DefinitelyTyped/jasmine/jasmine.d.ts#dc9dabe74a5be62613b17a3605309783a12ff28a",
+    "jasmine": "registry:dt/jasmine#2.2.0+20160621224255",
 <% if (framework === 'angular1') { -%>
 <% if (router === 'uirouter') { -%>
-    "angular-ui-router": "registry:dt/angular-ui-router#1.1.5+20160707113237",
+    "angular-ui-router": "registry:dt/angular-ui-router#1.1.5+20160810191828",
 <% } -%>
-    "angular": "registry:dt/angular#1.5.0+20160627105203",
-    "angular-mocks": "github:DefinitelyTyped/DefinitelyTyped/angularjs/angular-mocks.d.ts#dc9dabe74a5be62613b17a3605309783a12ff28a",
-    "jquery": "github:DefinitelyTyped/DefinitelyTyped/jquery/jquery.d.ts#dc9dabe74a5be62613b17a3605309783a12ff28a",
+    "angular": "registry:dt/angular#1.5.0+20160922195358",
+    "angular-mocks": "registry:dt/angular-mocks#1.5.0+20160608104721",
+    "jquery": "registry:dt/jquery#1.10.0+20160908203239",
 <% } -%>
 <% if (framework === 'react') { -%>
-    "axios": "github:DefinitelyTyped/DefinitelyTyped/axios/axios.d.ts#bcd5761826eb567876c197ccc6a87c4d05731054",
-    "react": "github:DefinitelyTyped/DefinitelyTyped/react/react.d.ts#dc9dabe74a5be62613b17a3605309783a12ff28a",
-    "react-dom": "github:DefinitelyTyped/DefinitelyTyped/react/react-dom.d.ts#dc9dabe74a5be62613b17a3605309783a12ff28a",
-    "react-addons-test-utils": "github:DefinitelyTyped/DefinitelyTyped/react/react-addons-test-utils.d.ts#dc9dabe74a5be62613b17a3605309783a12ff28a",
+    "axios": "registry:dt/axios#0.9.1+20160629101425",
+    "react": "registry:dt/react#0.14.0+20160927082313",
+    "react-dom": "registry:dt/react-dom#0.14.0+20160412154040",
+    "react-addons-test-utils": "registry:dt/react-addons-test-utils#0.14.0+20160427035638",
     "classnames": "registry:dt/classnames#0.0.0+20160316155526",
 <% } -%>
 <% if (framework !== 'react' && modules === 'webpack') { -%>
-    "require": "registry:dt/require#2.1.20+20160316155526",
+    "require": "registry:dt/require#2.1.20+20160919185614",
 <% } -%>
     "es6-shim": "registry:dt/es6-shim#0.31.2+20160602141504"
 <% if (framework === 'react') { -%>
   },
   "dependencies": {
 <% if (router === 'router') { -%>
-    "react-router": "registry:npm/react-router#2.4.0+20160628165748",
+    "react-router": "registry:npm/react-router#2.4.0+20160915183637",
 <% } -%>
     "react-redux": "registry:npm/react-redux#4.4.0+20160207114942"
   }


### PR DESCRIPTION
Was great to see Angular 2.0.0 support released, then I got a `WARN` oh no!

> typings WARN deprecated 9/20/2016: "registry:dt/require#2.1.20+20160316155526" is deprecated (updated, replaced or removed)

Whilst I'm here, I've updated all the typings ;)
