### PR TITLE
packing all typescript files into inject mod

### DIFF
--- a/generators/app/templates/conf/ts.conf.json
+++ b/generators/app/templates/conf/ts.conf.json
@@ -8,6 +8,9 @@
     "experimentalDecorators": true,
     "removeComments": false,
     "noImplicitAny": false,
+<% if (modules === 'inject') { -%>
+    "outFile": "./merged_typescript_files.js",
+<% } -%>
     "typeRoots": ["node_modules/@types/"],
     "types": [
 <% if (framework === 'angular1') { -%>


### PR DESCRIPTION
if we didn't merge them we will get errors because of module loading requests. while we don't have any module system in the inject mod. so merging files together is the best solution and typescript handles it itself. user can access ts files using their sourcemaps.